### PR TITLE
Do not place 'custom-theme' and custom-module' downloads into /*/contrib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "web/modules/{$name}": ["type:custom-module"],
+            "web/themes/{$name}": ["type:custom-theme"],
+            "web/profiles/{$name}": ["type:custom-profile"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         }
     }


### PR DESCRIPTION
If everything else is pulled in by composer, it makes sense to treat our own extensions as included additions also!

Not least because it will help to get the team thinking about designing their custom code as re-usable libraries more and out of the old one-big-git-blob approach!
But also for consistency with the way the rest of the project does..

If adding our own custom project-specific themes and modules via composer, do NOT place them in `contrib` because it's not 'contrib' - which to me means 'official drupal.org stuff' ..
_A custom theme could possible go deeper into `web/themes/custom/themename` ... but that `custom` layer is redundant in practice._ I would accept that as an alternative.
Just place it into `web/themes/themename` where it can be seen. Same for modules (mostly project-specific 'features').

We then add our own projects by describing them as `"type": "custom-theme",` and defining the repository source:

```

   "require": {
        ....
        "sparksi/projectname": "8.*",
    }
    "repositories": [
        {
            "type": "composer",
            "url": "https://packagist.drupal-composer.org"
        },
        {
            "type": "package",
            "package": {
                "name": "sparksi/projectname",
                "version": "8.1.x-dev",
                "type": "custom-theme",
                "source": {
                    "url": "git@gitlab.com:sparksi/projectname.theme-d8.git",
                    "type": "git",
                    "reference": "master"
                }
            }
        }
  }

```

This ends up with our custom theme being pulled in to
`web/themes/projectname`